### PR TITLE
Fix UID/GID to match skiperator's runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ EXPOSE 8080
 
 ENV QGIS_PROJECT_FILE=/etc/qgisserver/test.qgs
 
+# Set www-data UID and GID to 150 to match skiperator requirements
+RUN usermod -u 150 www-data \
+    && groupmod -g 150 www-data
+
 USER www-data:root
 
 COPY --chown=www-data:root ./fonts /etc/qgisserver/fonts


### PR DESCRIPTION
When running on SKIP, the UID and GID is hard coded to be 150. May cause issues if the user inside the container don't match that.